### PR TITLE
Update JLCODE5.jl to θ=π/4 s.t. cot(θ) = 1.0

### DIFF
--- a/examples/JLCODE5.jl
+++ b/examples/JLCODE5.jl
@@ -5,7 +5,7 @@ using LinearAlgebra;
 const Fu = F_utilities;
 
 N   = 10;
-theta   = pi/8;
+theta   = pi/4;
 
 H_APBC          = Fu.TFI_Hamiltonian(N, theta; PBC=-1);
 HD_APBC, U_APBC = Fu.Diag_h(H_APBC);


### PR DESCRIPTION
Hi Jacopo!
I believe your example 5 makes much more sense at the critical Ising point where $h/J = 1$.
The plots also look much more accurate when comparing "analytical" to "numerical" data points!